### PR TITLE
Improved Post Processing Fields Management

### DIFF
--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -242,6 +242,9 @@ namespace FEDD {
         void setLocalHistoryUpdated(vec_dbl_Type historyUpdated);
 
         int getHistoryLength() {return historyLength_;};
+
+        virtual std::vector<std::string> getPostDataNames();
+        virtual std::map<std::string, int> getFieldNameToPosition();
     protected:
 
         /*!

--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -233,6 +233,8 @@ namespace FEDD {
 
         vec_dbl_Type getLocalHistoryUpdated() {return historyUpdated_;};
 
+        const std::vector<std::string>& getPostDataNames() const { return postDataNames_; }
+
          /*!
          \brief Set history values of element
          \return values
@@ -286,6 +288,7 @@ namespace FEDD {
         double timeIncrement_;
         GO globalElementID_;
         vec2D_dbl_ptr_Type postProcessingData_;
+        std::vector<std::string> postDataNames_;
 
         vec_dbl_Type historyUpdated_;
 		vec_dbl_Type history_;

--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -291,6 +291,7 @@ namespace FEDD {
         GO globalElementID_;
         vec2D_dbl_ptr_Type postProcessingData_;
         std::vector<std::string> postDataNames_;
+        std::map<std::string, int> fieldNameToPosition_;
 
         vec_dbl_Type historyUpdated_;
 		vec_dbl_Type history_;

--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -233,10 +233,6 @@ namespace FEDD {
 
         vec_dbl_Type getLocalHistoryUpdated() {return historyUpdated_;};
 
-        std::vector<std::string> getPostDataNames()  { return postDataNames_; }
-
-        std::map<std::string, int> getFieldNameToPosition()  { return fieldNameToPosition_; }
-
          /*!
          \brief Set history values of element
          \return values
@@ -290,8 +286,6 @@ namespace FEDD {
         double timeIncrement_;
         GO globalElementID_;
         vec2D_dbl_ptr_Type postProcessingData_;
-        std::vector<std::string> postDataNames_;
-        std::map<std::string, int> fieldNameToPosition_;
 
         vec_dbl_Type historyUpdated_;
 		vec_dbl_Type history_;

--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -233,7 +233,9 @@ namespace FEDD {
 
         vec_dbl_Type getLocalHistoryUpdated() {return historyUpdated_;};
 
-        const std::vector<std::string>& getPostDataNames() const { return postDataNames_; }
+        std::vector<std::string> getPostDataNames()  { return postDataNames_; }
+
+        std::map<std::string, int> getFieldNameToPosition()  { return fieldNameToPosition_; }
 
          /*!
          \brief Set history values of element

--- a/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_decl.hpp
@@ -243,8 +243,8 @@ namespace FEDD {
 
         int getHistoryLength() {return historyLength_;};
 
-        virtual std::vector<std::string> getPostDataNames();
-        virtual std::map<std::string, int> getFieldNameToPosition();
+        virtual std::vector<std::string> getPostDataNames(){return {};};
+        virtual std::map<std::string, int> getFieldNameToPosition(){return {};};
     protected:
 
         /*!

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
@@ -73,8 +73,8 @@ namespace FEDD
 
 		void updateDomainData(std::string dataName, double dataValue);
 
-                const std::vector<std::string>& getPostDataNames() const { return postDataNames_; }
-                const std::map<std::string, int>& getFieldNameToPosition() const { return fieldNameToPosition_; }
+                std::vector<std::string> getPostDataNames() { return postDataNames_; }
+                std::map<std::string, int> getFieldNameToPosition() { return fieldNameToPosition_; }
 
 	protected:
 		AssembleFE_SCI_SMC_Active_Growth_Reorientation(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type params, tuple_disk_vec_ptr_Type tuple);

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
@@ -74,6 +74,7 @@ namespace FEDD
 		void updateDomainData(std::string dataName, double dataValue);
 
                 const std::vector<std::string>& getPostDataNames() const { return postDataNames_; }
+                const std::map<std::string, int>& getFieldNameToPosition() const { return fieldNameToPosition_; }
 
 	protected:
 		AssembleFE_SCI_SMC_Active_Growth_Reorientation(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type params, tuple_disk_vec_ptr_Type tuple);
@@ -123,6 +124,7 @@ namespace FEDD
 
           std::vector<std::string> domainDataNames_;
           std::vector<std::string> postDataNames_;
+          std::map<std::string, int> fieldNameToPosition_;
 
           vec_dbl_Type residuumRint_;
           vec_dbl_Type residuumRdyn_;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
@@ -73,6 +73,8 @@ namespace FEDD
 
 		void updateDomainData(std::string dataName, double dataValue);
 
+                const std::vector<std::string>& getPostDataNames() const { return postDataNames_; }
+
 	protected:
 		AssembleFE_SCI_SMC_Active_Growth_Reorientation(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type params, tuple_disk_vec_ptr_Type tuple);
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
@@ -66,7 +66,6 @@ namespace FEDD
 		for (int i = 0; i < this->postDataLength_; i++)
 		{
 			this->postDataNames_[i] = std::string(postDataNames[i]);
-			std::cout << " Post Data Names " << i << " " << this->postDataNames_[i] << std::endl;
 		}
 
 		// Create map from field name to position in postDataNames_

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
@@ -66,7 +66,7 @@ namespace FEDD
 		for (int i = 0; i < this->postDataLength_; i++)
 		{
 			this->postDataNames_[i] = std::string(postDataNames[i]);
-			// cout << " Post Data Names " << i << " " << this->postDataNames_[i] << endl;
+			std::cout << " Post Data Names " << i << " " << this->postDataNames_[i] << std::endl;
 		}
 
 		// Create map from field name to position in postDataNames_

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
@@ -69,6 +69,11 @@ namespace FEDD
 			// cout << " Post Data Names " << i << " " << this->postDataNames_[i] << endl;
 		}
 
+		// Create map from field name to position in postDataNames_
+    	for (int i = 0; i < postDataNames_.size(); i++) {
+        	fieldNameToPosition_[postDataNames_[i]] = i;
+    	}
+
 		this->residuumRint_.resize(30, 0.0);
 		this->residuumRc_.resize(10, 0.0);
 		this->residuumRdyn_.resize(30, 0.0);

--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -673,7 +673,7 @@ class FE {
                         bool callFillComplete=true,
                         int FELocExternal=-1);
 
-    void postProcessing(int type, MultiVectorPtr_Type &postProcessingVec);
+    void postProcessing(std::string type, MultiVectorPtr_Type &postProcessingVec);
     
 
     void assemblyLaplaceAssFE(int dim,

--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -741,6 +741,7 @@ class FE {
 
     BlockMultiVectorPtr_Type getHistoryValues();
     void setHistoryValues(LO T,vec_dbl_Type history);
+    std::vector<std::string> getPostDataNames();
 
 
 /* ----------------------------------------------------------------------------------------*/

--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -674,6 +674,8 @@ class FE {
                         int FELocExternal=-1);
 
     void postProcessing(std::string type, MultiVectorPtr_Type &postProcessingVec);
+
+    std::vector<std::string> getPostDataNames();
     
 
     void assemblyLaplaceAssFE(int dim,
@@ -741,7 +743,6 @@ class FE {
 
     BlockMultiVectorPtr_Type getHistoryValues();
     void setHistoryValues(LO T,vec_dbl_Type history);
-    std::vector<std::string> getPostDataNames();
 
 
 /* ----------------------------------------------------------------------------------------*/

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -784,7 +784,7 @@ void FE<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Ty
     56 -- "SrDir2"
     57 -- "SrDir3"*/
 template <class SC, class LO, class GO, class NO>
-void FE<SC, LO, GO, NO>::postProcessing(int type, MultiVectorPtr_Type &postProcessingVec)
+void FE<SC, LO, GO, NO>::postProcessing(std::string type, MultiVectorPtr_Type &postProcessingVec)
 {
     // Map for temporary vectors for import and export
     MapConstPtr_Type mapRep = this->domainVec_[0]->getMapRepeated();
@@ -803,6 +803,10 @@ void FE<SC, LO, GO, NO>::postProcessing(int type, MultiVectorPtr_Type &postProce
     resRep->putScalar(0.);
     Teuchos::ArrayRCP<SC>  arrayRep = resRep->getDataNonConst(0);
 
+    auto fieldNameToPosition = assemblyFEElements_[0]->getFieldNameToPosition();
+
+    TEUCHOS_TEST_FOR_EXCEPTION(fieldNameToPosition.count(type) == 0, std::logic_error, "Unknown post-processing field type: '" + type + "'");
+    int position = fieldNameToPosition.at(type);
     // Iterating over all elements
     for (UN T=0; T<assemblyFEElements_.size(); T++) {
 

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -804,10 +804,16 @@ void FE<SC, LO, GO, NO>::postProcessing(std::string type, MultiVectorPtr_Type &p
     Teuchos::ArrayRCP<SC>  arrayRep = resRep->getDataNonConst(0);
 
     auto fieldNameToPosition = assemblyFEElements_[0]->getFieldNameToPosition();
-
-    TEUCHOS_TEST_FOR_EXCEPTION(fieldNameToPosition.count(type) == 0, std::logic_error, "Unknown post-processing field type: '" + type + "'");
-    int position = fieldNameToPosition.at(type);
-    // Iterating over all elements
+    auto postDataNames = assemblyFEElements_[0]->getPostDataNames();
+    if (fieldNameToPosition.count(type) == 0) {
+        std::string availableTypes;
+        for (size_t i = 0; i < postDataNames.size(); ++i) {
+            if (i > 0) availableTypes += ", ";
+            availableTypes += postDataNames[i];
+        }
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Unknown post-processing field type: '" + type +
+        "', available types: " + availableTypes);
+    }
     for (UN T=0; T<assemblyFEElements_.size(); T++) {
 
         vec_LO_Type nodeList = elements->getElement(T).getVectorNodeList();

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -816,7 +816,7 @@ void FE<SC, LO, GO, NO>::postProcessing(std::string type, MultiVectorPtr_Type &p
         
         for(int i=0; i< 10; i++){
             arrayMultiRep[nodeList[i]] += (*postProcessingData)[i][0]; // this column of the postprocessing data contains some sort of scaling.
-            arrayRep[nodeList[i]] +=  (*postProcessingData)[i][type]; //*(*postProcessingData)[i][0]; // per node the index 'type' stands for a different post processing value
+            arrayRep[nodeList[i]] +=  (*postProcessingData)[i][position]; //*(*postProcessingData)[i][0]; // per node the index 'type' stands for a different post processing value
         }
     }
     

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -814,6 +814,7 @@ void FE<SC, LO, GO, NO>::postProcessing(std::string type, MultiVectorPtr_Type &p
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Unknown post-processing field type: '" + type +
         "', available types: " + availableTypes);
     }
+    int position = fieldNameToPosition.at(type);
     for (UN T=0; T<assemblyFEElements_.size(); T++) {
 
         vec_LO_Type nodeList = elements->getElement(T).getVectorNodeList();

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -839,6 +839,12 @@ void FE<SC, LO, GO, NO>::postProcessing(int type, MultiVectorPtr_Type &postProce
 }
 
 template <class SC, class LO, class GO, class NO>
+std::vector<std::string> FE<SC, LO, GO, NO>::getPostDataNames()
+{
+    return assemblyFEElements_[0]->getPostDataNames();
+}
+
+template <class SC, class LO, class GO, class NO>
 typename FE<SC, LO, GO, NO>::BlockMultiVectorPtr_Type FE<SC, LO, GO, NO>::getHistoryValues()
 {
     // We are only concerned with element information. We dont need any communication for that

--- a/feddlib/problems/examples/arteries/artery_dan/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_dan/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_dan/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_dan/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_dan.exe

--- a/feddlib/problems/examples/arteries/artery_dan_withDrug/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_dan_withDrug/simulationParameters.xml
@@ -24,7 +24,18 @@
         <Parameter name="Coupling Type" type="string" value="implicit"/>
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
-
+        
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_dan_withDrug/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_dan_withDrug/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_dan_withDrug.exe

--- a/feddlib/problems/examples/arteries/artery_kim/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_kim/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_kim/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_kim/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_kim.exe

--- a/feddlib/problems/examples/arteries/artery_kim_withDrug/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_kim_withDrug/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_kim_withDrug/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_kim_withDrug/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_kim_withDrug.exe

--- a/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
@@ -25,6 +25,7 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{vonMisesStress, SCirc, W, Growth1}"/>
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
@@ -75,7 +75,7 @@
         <Parameter name="Export drag and lift" type="bool" value="true"/>
 
         <Parameter name="Export Stress" type="bool" value="true"/>
-        <Parameter name="Every X Second" type="double" value="20."/> <!-- Output frequency for stresses and co. during normal phase. 1 = every time step. 10 = every tenth time step -->
+        <Parameter name="Every X Second" type="double" value="1."/> <!-- Output frequency for stresses and co. during normal phase. 1 = every time step. 10 = every tenth time step -->
         <!-- <Parameter name="Every X Second Heartbeat" type="double" value="0.01"/> --> <!-- Output frequency for stresses and co. during heartbeat phases. Currently no heartbeat rhs -->
 
         <Parameter name="Preconditioner Method" type="string" value="Monolithic"/> <!-- Monolithic, FaCSI, FaCSI-Teko -->

--- a/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
@@ -25,7 +25,7 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
-        <Parameter name="Post Processing Fields" type="Array(string)" value="{vonMisesStress, SCirc, W, Growth1}"/>
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, W, DetFe, DetFg}"/>
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
@@ -75,7 +75,7 @@
         <Parameter name="Export drag and lift" type="bool" value="true"/>
 
         <Parameter name="Export Stress" type="bool" value="true"/>
-        <Parameter name="Every X Second" type="double" value="1."/> <!-- Output frequency for stresses and co. during normal phase. 1 = every time step. 10 = every tenth time step -->
+        <Parameter name="Every X Second" type="double" value="20."/> <!-- Output frequency for stresses and co. during normal phase. 1 = every time step. 10 = every tenth time step -->
         <!-- <Parameter name="Every X Second Heartbeat" type="double" value="0.01"/> --> <!-- Output frequency for stresses and co. during heartbeat phases. Currently no heartbeat rhs -->
 
         <Parameter name="Preconditioner Method" type="string" value="Monolithic"/> <!-- Monolithic, FaCSI, FaCSI-Teko -->

--- a/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula/simulationParameters.xml
@@ -25,7 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
-        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, W, DetFe, DetFg}"/>
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_narula/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_narula/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_narula.exe

--- a/feddlib/problems/examples/arteries/artery_narula_withDrug/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_narula_withDrug/simulationParameters.xml
@@ -24,7 +24,18 @@
         <Parameter name="Coupling Type" type="string" value="implicit"/>
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
-
+        
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_narula_withDrug/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_narula_withDrug/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_narula_withDrug.exe

--- a/feddlib/problems/examples/arteries/artery_phini/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_phini/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_phini/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_phini/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_phini.exe

--- a/feddlib/problems/examples/arteries/artery_phini_withDrug/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_phini_withDrug/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_phini_withDrug/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_phini_withDrug/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_phini_withDrug.exe

--- a/feddlib/problems/examples/arteries/artery_plass/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_plass/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_plass/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_plass/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_plass.exe

--- a/feddlib/problems/examples/arteries/artery_plass_withDrug/simulationParameters.xml
+++ b/feddlib/problems/examples/arteries/artery_plass_withDrug/simulationParameters.xml
@@ -25,6 +25,17 @@
         <Parameter name="Accelerated Active Until" type="double" value="220.0"/>
         <Parameter name="Active Acceleration Multiplier" type="double" value="20.0"/>
 
+        <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/> <!-- Choose from 
+                       {"Volume","Sxx","Sxy","Sxz","Syx","Syy",
+                       "Syz","Szx","Szy","Szz","MisesStress","SCirc",
+                       "SAxial","SRadial","Exx","Exy","Exz","Eyx",
+                       "Eyy","Eyz","Ezx","Ezy","Ezz","W",
+                       "Growth1","Growth2","Growth3","Stretch1","Stretch2","DetF",
+                       "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+                       "Ag3n1","Ag3n2","Ag3n3","a11","a12","a13",
+                       "a21","a22","a23","nC1","nC2","nD1",
+                       "nD2","ScDir1","ScDir2","ScDir3","SaDir1","SaDir2",
+                       "SaDir3","SrDir1","SrDir2","SrDir3","DetFg","DetFe"}-->
        
         <Parameter name="relNonLinTol" type="double" value="1.0e-7"/>
         <Parameter name="absNonLinTol" type="double" value="1.0e-7"/>

--- a/feddlib/problems/examples/arteries/artery_plass_withDrug/slurm-script_elysium.sh
+++ b/feddlib/problems/examples/arteries/artery_plass_withDrug/slurm-script_elysium.sh
@@ -16,5 +16,6 @@
 
 unset SLURM_EXPORT_ENV
 
+module load intel-oneapi-mkl
 module load intel-oneapi-mpi/2021.12.1-qdmj2yh
 srun --mpi=pmi2 ./problems_artery_plass_withDrug.exe

--- a/feddlib/problems/specific/SCI_decl.hpp
+++ b/feddlib/problems/specific/SCI_decl.hpp
@@ -178,7 +178,7 @@ public:
 
     virtual void calculateNonLinResidualVec(std::string type="standard", double time=0.) const; //standard or reverse    
     
-    BlockMultiVectorPtr_Type getPostProcessingData() const;
+    BlockMultiVectorPtr_Type getPostProcessingData();
 
     vec_string_Type getPostprocessingNames();
 

--- a/feddlib/problems/specific/SCI_decl.hpp
+++ b/feddlib/problems/specific/SCI_decl.hpp
@@ -208,6 +208,7 @@ private:
     std::string materialModel_;
     vec_dbl_Type valuesForExport_;
     vec_string_Type postProcessingnames_;
+    std::vector<std::string> requestedFields_; // The post processing fields that are requested as per the parameters file
     bool geometryExplicit_;
     mutable BlockMatrixPtr_Type systemC_;
     ExporterTxtPtr_Type exporterIterationsChem_;

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -291,7 +291,7 @@ void SCI<SC,LO,GO,NO>::reAssemble(std::string type) const
     }
 
     else if (type == "ComputeSolidRHSInTime"){
-        if(this->verbose_)
+        if (this->verbose_)
             std::cout << "-- Assembly (ComputeSolidRHSInTime)" << '\n';
           
         computeSolidRHSInTime();
@@ -1262,16 +1262,10 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     // Initialize the post-processing names if not already done
 
     if (postProcessingnames_.empty()) {
-        std::cout << "Initializing post-processing names..." << std::endl;
+        if(this->verbose_)
+            std::cout << "Initializing post-processing names..." << std::endl;
         postProcessingnames_ = this->feFactory_->getPostDataNames();
     }
-
-    // Print out the post-processing names for debugging
-    std::cout << "Post-processing names: ";
-    for (const auto& name : postProcessingnames_) {
-        std::cout << name << " ";
-    }
-    std::cout << std::endl;
 
     // Read the desired post-processing fields from the parameter list
     Teuchos::Array<std::string> requestedField;

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1277,12 +1277,6 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     // Create BlockMultiVector with the number of requested fields
     BlockMultiVectorPtr_Type postProcess = Teuchos::rcp(new BlockMultiVector_Type(requestedFields.size()));
 
-    // Create map from field name to position in postProcessingnames_
-    std::map<std::string, int> fieldNameToPosition;
-    for (int i = 0; i < postProcessingnames_.size(); i++) {
-        fieldNameToPosition[postProcessingnames_[i]] = i;
-    }
-
     // Populate the BlockMultiVector with the requested fields
     for(int i = 0; i < requestedFields.size(); i++) {
         MultiVectorPtr_Type fieldData = Teuchos::rcp(new MultiVector_Type(this->getDomain(0)->getMapUnique()));

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1133,7 +1133,7 @@ void SCI<SC,LO,GO,NO>::updateChemInTime() const
     }
 }
 template<class SC,class LO,class GO,class NO>
-typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostProcessingData() const
+typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostProcessingData()
 {
     // BlockMultiVectorPtr_Type postProcess =Teuchos::rcp(new BlockMultiVector_Type(10)) ;
         
@@ -1262,8 +1262,7 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     // Initialize the post-processing names if not already done
 
     if (postProcessingnames_.empty()) {
-        auto tmp = this->feFactory_->getPostDataNames();
-        postProcessingnames_ = std::vector<std::string>(tmp.begin(), tmp.end());
+        postProcessingnames_ = this->feFactory_->getPostDataNames();
     }
 
     // Read the desired post-processing fields from the parameter list

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1297,13 +1297,18 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
         postProcess->addBlock(fieldData, i);
     }
 
+    // This runs after the above block because it ensures that the requested field is available in the postprocessing data
+    if(requestedFields_.empty()) {
+        requestedFields_ = vec_string_Type(requestedField.begin(), requestedField.end());
+    }
+
     return postProcess;
 }
 
 template<class SC,class LO,class GO,class NO>
 vec_string_Type SCI<SC,LO,GO,NO>::getPostprocessingNames()
 {
-    return postProcessingnames_;
+    return requestedFields_;
 }
 
 template<class SC,class LO,class GO,class NO>

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1265,6 +1265,13 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
         postProcessingnames_ = this->feFactory_->getPostDataNames();
     }
 
+    // Print out the post-processing names for debugging
+    std::cout << "Post-processing names: ";
+    for (const auto& name : postProcessingnames_) {
+        std::cout << name << " ";
+    }
+    std::cout << std::endl;
+
     // Read the desired post-processing fields from the parameter list
     Teuchos::Array<std::string> requestedField;
     if (this->parameterList_->sublist("Parameter").isParameter("Post Processing Fields")) {

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1262,7 +1262,8 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     // Initialize the post-processing names if not already done
 
     if (postProcessingnames_.empty()) {
-        postProcessingnames_ = this->feFactory_->getPostDataNames();
+        auto tmp = this->feFactory_->getPostDataNames();
+        postProcessingnames_ = std::vector<std::string>(tmp.begin(), tmp.end());
     }
 
     // Read the desired post-processing fields from the parameter list

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -70,7 +70,7 @@ materialModel_( parameterListSCI->sublist("Parameter").get("Structure Model","SC
         exporterIterationsChem_->setup( "linearIterations_chem", this->comm_ );
     }
 
-    postProcessingnames_ = this->feFactory_->getPostDataNames();
+    // postProcessingnames_ = this->feFactory_->getPostDataNames();
     // postProcessingnames_.resize(23);
     // postProcessingnames_ = {"vonMisesStress", "SCirc","SAxial","SRadial","W","Growth1","Growth2","Growth3","Strech1","Strech2","nC1","nC2","nD1","nD2","Agn11","Agn12","Agn13","Agn21","Agn22","Agn23","Agn31","Agn32","Agn33"};
 
@@ -1259,44 +1259,34 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     
     // return postProcess;
 
+    // Initialize the post-processing names if not already done
 
+    if (postProcessingnames_.empty()) {
+        postProcessingnames_ = this->feFactory_->getPostDataNames();
+    }
 
     // Read the desired post-processing fields from the parameter list
-    Teuchos::Array<std::string> requestedFields;
+    Teuchos::Array<std::string> requestedField;
     if (this->parameterList_->sublist("Parameter").isParameter("Post Processing Fields")) {
-        requestedFields = this->parameterList_->sublist("Parameter").get("Post Processing Fields", 
+        requestedField = this->parameterList_->sublist("Parameter").get("Post Processing Fields", 
                                                                         Teuchos::Array<std::string>());
     } else {
         // Fallback to all available fields if not specified
-        requestedFields.resize(postProcessingnames_.size());
+        requestedField.resize(postProcessingnames_.size());
         for (int i = 0; i < postProcessingnames_.size(); i++) {
-            requestedFields[i] = postProcessingnames_[i];
+            requestedField[i] = postProcessingnames_[i];
         }
     }
 
+
     // Create BlockMultiVector with the number of requested fields
-    BlockMultiVectorPtr_Type postProcess = Teuchos::rcp(new BlockMultiVector_Type(requestedFields.size()));
+    BlockMultiVectorPtr_Type postProcess = Teuchos::rcp(new BlockMultiVector_Type(requestedField.size()));
 
     // Populate the BlockMultiVector with the requested fields
-    for(int i = 0; i < requestedFields.size(); i++) {
+    for(int i = 0; i < requestedField.size(); i++) {
         MultiVectorPtr_Type fieldData = Teuchos::rcp(new MultiVector_Type(this->getDomain(0)->getMapUnique()));
-        // Check if the requested field is available in the postProcessingnames_
-        auto it = fieldNameToPosition.find(requestedFields[i]);
-        if (it != fieldNameToPosition.end()) {
-            this->feFactory_->postProcessing(it->second, fieldData);
-            postProcess->addBlock(fieldData, i);
-        }
-        else{
-            // Log warning or throw error for unknown field
-            std::string availableFields = "";
-            for (size_t j = 0; j < postProcessingnames_.size(); ++j) {
-                if (j > 0) availableFields += ", ";
-                availableFields += postProcessingnames_[j];
-            }
-            TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, 
-                "Unknown post-processing field requested: " + requestedFields[i] + 
-                ". Available fields are: " + availableFields);
-        }
+        this->feFactory_->postProcessing(requestedField[i], fieldData);
+        postProcess->addBlock(fieldData, i);
     }
 
     return postProcess;

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -42,7 +42,7 @@ materialModel_( parameterListSCI->sublist("Parameter").get("Structure Model","SC
         problemStructure_ = Teuchos::rcp( new StructureProblem_Type( domainStructure, FETypeStructure, parameterListStructure ) );
         problemStructure_->initializeProblem();
     }
-    else{
+    else {
         problemStructureNonLin_ = Teuchos::rcp( new StructureNonLinProblem_Type( domainStructure, FETypeStructure, parameterListStructure) );
         problemStructureNonLin_->initializeProblem();
     }
@@ -70,8 +70,9 @@ materialModel_( parameterListSCI->sublist("Parameter").get("Structure Model","SC
         exporterIterationsChem_->setup( "linearIterations_chem", this->comm_ );
     }
 
-    postProcessingnames_.resize(23);
-    postProcessingnames_ = {"vonMisesStress", "SCirc","SAxial","SRadial","W","Growth1","Growth2","Growth3","Strech1","Strech2","nC1","nC2","nD1","nD2","Agn11","Agn12","Agn13","Agn21","Agn22","Agn23","Agn31","Agn32","Agn33"};
+    postProcessingnames_ = this->feFactory_->getPostDataNames();
+    // postProcessingnames_.resize(23);
+    // postProcessingnames_ = {"vonMisesStress", "SCirc","SAxial","SRadial","W","Growth1","Growth2","Growth3","Strech1","Strech2","nC1","nC2","nD1","nD2","Agn11","Agn12","Agn13","Agn21","Agn22","Agn23","Agn31","Agn32","Agn33"};
 
 }
 
@@ -186,7 +187,7 @@ void SCI<SC,LO,GO,NO>::assemble( std::string type ) const
             this->system_->addBlock(systemTmp->getBlock(0,0),0,0);
             this->systemC_->addBlock(systemTmp->getBlock(1,1),0,0);
         }
-        else{
+        else {
             this->system_->addBlock(systemTmp->getBlock(0,0),0,0);
             this->system_->addBlock(systemTmp->getBlock(0,1),0,1);
             this->system_->addBlock(systemTmp->getBlock(1,0),1,0);
@@ -1134,128 +1135,176 @@ void SCI<SC,LO,GO,NO>::updateChemInTime() const
 template<class SC,class LO,class GO,class NO>
 typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostProcessingData() const
 {
-    BlockMultiVectorPtr_Type postProcess =Teuchos::rcp(new BlockMultiVector_Type(10)) ;
+    // BlockMultiVectorPtr_Type postProcess =Teuchos::rcp(new BlockMultiVector_Type(10)) ;
         
-    /*
-    0 -- "Volume","
-    1 -- Sxx",
-    2 -- "Sxy"
-    3 -- "Sxz" 
-    4 -- "Syx"
-    5 -- "Syy"
-    6 -- "Syz" 
-    7 -- "Szx" 
-    8 -- "Szy" 
-    9 -- "Szz" 
-    10 -- "MisesStress" 
-    11 -- "SCirc"
-    12 -- "SAxial",
-    13 -- "SRadial"
-    14 -- "Exx"
-    15 -- "Exy"
-    16 -- "Exz" 
-    17 -- "Eyx"
-    18 -- "Eyy"
-    19 -- "Eyz" 
-    20 -- "Ezx"
-    21 -- "Ezy"
-    22 -- "Ezz"
-    23 -- "W"
-    24 -- "Growth1"
-    25 -- "Growth2" 
-    26 -- "Growth3"
-    27 -- "Stretch1"
-    28 -- "Stretch2"
-    29 -- "DetF",
-    30 - 38      "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
-                       "Ag3n1","Ag3n2","Ag3n3"
-    39 -- "a11"
-    40 -- "a12"
-    41 -- "a13"
-    42 -- "a21"
-    43 -- "a22"
-    44 -- "a23"
-    45 -- "nC1" <----- !!
-    46 -- "nC2" <----- !!
-    47 -- "nD1" <----- !! 
-    48 -- "nD2" <----- !!
-    49 -- "ScDir1"
-    50 -- "ScDir2" 
-    51 -- "ScDir3" 
-    52 -- "SaDir1"
-    53 -- "SaDir2"
-    54 -- "SaDir3"
-    55 -- "SrDir1"
-    56 -- "SrDir2"
-    57 -- "SrDir3"*/
+    // /*
+    // 0 -- "Volume","
+    // 1 -- Sxx",
+    // 2 -- "Sxy"
+    // 3 -- "Sxz" 
+    // 4 -- "Syx"
+    // 5 -- "Syy"
+    // 6 -- "Syz" 
+    // 7 -- "Szx" 
+    // 8 -- "Szy" 
+    // 9 -- "Szz" 
+    // 10 -- "MisesStress" 
+    // 11 -- "SCirc"
+    // 12 -- "SAxial",
+    // 13 -- "SRadial"
+    // 14 -- "Exx"
+    // 15 -- "Exy"
+    // 16 -- "Exz" 
+    // 17 -- "Eyx"
+    // 18 -- "Eyy"
+    // 19 -- "Eyz" 
+    // 20 -- "Ezx"
+    // 21 -- "Ezy"
+    // 22 -- "Ezz"
+    // 23 -- "W"
+    // 24 -- "Growth1"
+    // 25 -- "Growth2" 
+    // 26 -- "Growth3"
+    // 27 -- "Stretch1"
+    // 28 -- "Stretch2"
+    // 29 -- "DetF",
+    // 30 - 38      "Ag1n1","Ag1n2","Ag1n3","Ag2n1","Ag2n2","Ag2n3",
+    //                    "Ag3n1","Ag3n2","Ag3n3"
+    // 39 -- "a11"
+    // 40 -- "a12"
+    // 41 -- "a13"
+    // 42 -- "a21"
+    // 43 -- "a22"
+    // 44 -- "a23"
+    // 45 -- "nC1" <----- !!
+    // 46 -- "nC2" <----- !!
+    // 47 -- "nD1" <----- !! 
+    // 48 -- "nD2" <----- !!
+    // 49 -- "ScDir1"
+    // 50 -- "ScDir2" 
+    // 51 -- "ScDir3" 
+    // 52 -- "SaDir1"
+    // 53 -- "SaDir2"
+    // 54 -- "SaDir3"
+    // 55 -- "SrDir1"
+    // 56 -- "SrDir2"
+    // 57 -- "SrDir3"*/
 
-    MultiVectorPtr_Type vonMisesStress = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(10, vonMisesStress);
+    // MultiVectorPtr_Type vonMisesStress = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(10, vonMisesStress);
 
-    MultiVectorPtr_Type SCirc = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(11, SCirc);
+    // MultiVectorPtr_Type SCirc = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(11, SCirc);
 
-    MultiVectorPtr_Type SAxial = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(12, SAxial);
+    // MultiVectorPtr_Type SAxial = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(12, SAxial);
 
-    MultiVectorPtr_Type SRadial = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(13, SRadial);
+    // MultiVectorPtr_Type SRadial = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(13, SRadial);
 
-    MultiVectorPtr_Type W = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(23, W);
+    // MultiVectorPtr_Type W = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(23, W);
 
-    MultiVectorPtr_Type Growth1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(24, Growth1);
+    // MultiVectorPtr_Type Growth1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(24, Growth1);
 
-    MultiVectorPtr_Type Growth2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(25, Growth2);
+    // MultiVectorPtr_Type Growth2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(25, Growth2);
 
-    MultiVectorPtr_Type Growth3 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(26, Growth3);
+    // MultiVectorPtr_Type Growth3 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(26, Growth3);
 
-    MultiVectorPtr_Type Strech1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(27, Strech1);
+    // MultiVectorPtr_Type Strech1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(27, Strech1);
 
-    MultiVectorPtr_Type Strech2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(28, Strech2);
+    // MultiVectorPtr_Type Strech2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(28, Strech2);
 
-    std::vector<MultiVectorPtr_Type> Ag1n;
+    // std::vector<MultiVectorPtr_Type> Ag1n;
 
-    for(int i=30;i<39;i++)
-    {
-        Ag1n.push_back(Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() )));
-        this->feFactory_->postProcessing(i, Ag1n[i-30]);
+    // for(int i=30;i<39;i++)
+    // {
+    //     Ag1n.push_back(Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() )));
+    //     this->feFactory_->postProcessing(i, Ag1n[i-30]);
+    // }
+
+    // MultiVectorPtr_Type nC1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(45, nC1);
+
+    // MultiVectorPtr_Type nC2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(46, nC2);
+
+    // MultiVectorPtr_Type nD1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(47, nD1);
+
+    // MultiVectorPtr_Type nD2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
+    // this->feFactory_->postProcessing(48, nD2);
+
+    // postProcess->addBlock(vonMisesStress,0);
+    // postProcess->addBlock(SCirc,1);
+    // postProcess->addBlock(SAxial,2);
+    // postProcess->addBlock(SRadial,3);
+    // postProcess->addBlock(W,4);
+    // postProcess->addBlock(Growth1,5);
+    // postProcess->addBlock(Growth2,6);
+    // postProcess->addBlock(Growth3,7);
+    // postProcess->addBlock(Strech1,8);
+    // postProcess->addBlock(Strech2,9);
+    // postProcess->addBlock(nC1,10);
+    // postProcess->addBlock(nC2,11);
+    // postProcess->addBlock(nD1,12);
+    // postProcess->addBlock(nD2,13);
+    // for(int i=0;i<Ag1n.size();i++)
+    //     postProcess->addBlock(Ag1n[i],14+i);
+    
+    // return postProcess;
+
+
+
+    // Read the desired post-processing fields from the parameter list
+    Teuchos::Array<std::string> requestedFields;
+    if (this->parameterList_->sublist("Parameter").isParameter("Post Processing Fields")) {
+        requestedFields = this->parameterList_->sublist("Parameter").get("Post Processing Fields", 
+                                                                        Teuchos::Array<std::string>());
+    } else {
+        // Fallback to all available fields if not specified
+        requestedFields.resize(postProcessingnames_.size());
+        for (int i = 0; i < postProcessingnames_.size(); i++) {
+            requestedFields[i] = postProcessingnames_[i];
+        }
     }
 
-    MultiVectorPtr_Type nC1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(45, nC1);
+    // Create BlockMultiVector with the number of requested fields
+    BlockMultiVectorPtr_Type postProcess = Teuchos::rcp(new BlockMultiVector_Type(requestedFields.size()));
 
-    MultiVectorPtr_Type nC2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(46, nC2);
+    // Create map from field name to position in postProcessingnames_
+    std::map<std::string, int> fieldNameToPosition;
+    for (int i = 0; i < postProcessingnames_.size(); i++) {
+        fieldNameToPosition[postProcessingnames_[i]] = i;
+    }
 
-    MultiVectorPtr_Type nD1 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(47, nD1);
+    // Populate the BlockMultiVector with the requested fields
+    for(int i = 0; i < requestedFields.size(); i++) {
+        MultiVectorPtr_Type fieldData = Teuchos::rcp(new MultiVector_Type(this->getDomain(0)->getMapUnique()));
+        // Check if the requested field is available in the postProcessingnames_
+        auto it = fieldNameToPosition.find(requestedFields[i]);
+        if (it != fieldNameToPosition.end()) {
+            this->feFactory_->postProcessing(it->second, fieldData);
+            postProcess->addBlock(fieldData, i);
+        }
+        else{
+            // Log warning or throw error for unknown field
+            std::string availableFields = "";
+            for (size_t j = 0; j < postProcessingnames_.size(); ++j) {
+                if (j > 0) availableFields += ", ";
+                availableFields += postProcessingnames_[j];
+            }
+            TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, 
+                "Unknown post-processing field requested: " + requestedFields[i] + 
+                ". Available fields are: " + availableFields);
+        }
+    }
 
-    MultiVectorPtr_Type nD2 = Teuchos::rcp(new MultiVector_Type( this->getDomain(0)->getMapUnique() ));
-    this->feFactory_->postProcessing(48, nD2);
-
-    postProcess->addBlock(vonMisesStress,0);
-    postProcess->addBlock(SCirc,1);
-    postProcess->addBlock(SAxial,2);
-    postProcess->addBlock(SRadial,3);
-    postProcess->addBlock(W,4);
-    postProcess->addBlock(Growth1,5);
-    postProcess->addBlock(Growth2,6);
-    postProcess->addBlock(Growth3,7);
-    postProcess->addBlock(Strech1,8);
-    postProcess->addBlock(Strech2,9);
-    postProcess->addBlock(nC1,10);
-    postProcess->addBlock(nC2,11);
-    postProcess->addBlock(nD1,12);
-    postProcess->addBlock(nD2,13);
-    for(int i=0;i<Ag1n.size();i++)
-        postProcess->addBlock(Ag1n[i],14+i);
-    
     return postProcess;
 }
 

--- a/feddlib/problems/specific/SCI_def.hpp
+++ b/feddlib/problems/specific/SCI_def.hpp
@@ -1262,6 +1262,7 @@ typename SCI<SC,LO,GO,NO>::BlockMultiVectorPtr_Type SCI<SC,LO,GO,NO>::getPostPro
     // Initialize the post-processing names if not already done
 
     if (postProcessingnames_.empty()) {
+        std::cout << "Initializing post-processing names..." << std::endl;
         postProcessingnames_ = this->feFactory_->getPostDataNames();
     }
 


### PR DESCRIPTION
- This PR deals with improving how post-processing fields are dealt with.
- Up until now, post-processing fields positions were hard coded and any changes in the AceGen element would not be automatically accounted for.
- Now post-processing fields are obtained from the AceGen element and the positions are automatically determined.
- The required post processing fields are to be set in the simulationParameters xml file as follows:
```
<ParameterList name="Parameter">
    <Parameter name="Post Processing Fields" type="Array(string)" value="{MisesStress, SCirc, SAxial, SRadial, W, Growth1, Growth2, Growth3, Stretch1, Stretch2, nC1, nD1, nC2, nD2, DetF, DetFe, DetFg}"/>
</ParameterList>
```